### PR TITLE
Add support for USB Host / CDC Devices based on FTDI chipsets (FT232)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.a
+*.o
+.DS_Store
+build/

--- a/_sdk/src/sdk_uart.c
+++ b/_sdk/src/sdk_uart.c
@@ -438,6 +438,7 @@ void UartStdioHandler(void)
 	while (UART_RecvReady(UART_STDIO_PORT)) // received data ready
 	{
 		ch = UART_RecvChar(UART_STDIO_PORT); // receive character from UART
+		UartPrint("%c", ch); // echo character
 		if (RingWriteReady(&UartStdioRxBuf, 1)) // if space in receive buffer
 			RingWrite8(&UartStdioRxBuf, ch); // write character
 		// otherwise lost received data if receive buffer is full

--- a/_sdk/usb_inc/sdk_usb_host_cdc.h
+++ b/_sdk/usb_inc/sdk_usb_host_cdc.h
@@ -112,9 +112,11 @@ void UsbHostCdcTerm();
 // open class interface (returns size of used interface, 0=not supported)
 // - At this point, no communications are allowed yet.
 u16 UsbHostCdcOpen(u8 dev_addr, const sUsbDescItf* itf, u16 max_len);
+u16 UsbHostCdcOpenFTDI(u8 dev_addr, const sUsbDescItf* itf, u16 max_len);
 
 // set config interface
 Bool UsbHostCdcCfg(u8 dev_addr, u8 itf_num);
+Bool UsbHostCdcCfgFTDI(u8 dev_addr, u8 itf_num);
 
 // transfer complete callback
 Bool UsbHostCdcComp(u8 dev_addr, u8 dev_epinx, u8 xres, u16 len);

--- a/_sdk/usb_src/sdk_usb_host.c
+++ b/_sdk/usb_src/sdk_usb_host.c
@@ -24,6 +24,7 @@
 
 #include "../inc/sdk_irq.h"
 #include "../inc/sdk_timer.h"
+#include "../inc/sdk_uart.h"
 #include "../usb_inc/sdk_usb_host.h"
 #include "../usb_inc/sdk_usb_host_cdc.h"	// USB Communication Device Class (host)
 #include "../usb_inc/sdk_usb_host_hid.h"	// USB Human Interface Device Class (host)
@@ -59,8 +60,8 @@ const sUsbHostDrv UsbHostDrv[] = {
 	{
 		UsbHostCdcInit,		// initialize class driver
 		UsbHostCdcTerm,		// terminate class driver
-		UsbHostCdcOpen,		// open device class interface
-		UsbHostCdcCfg,		// configure interface
+		UsbHostCdcOpenFTDI, 	// open device class interface
+		UsbHostCdcCfgFTDI,	// configure interface
 		UsbHostCdcComp,		// transfer complete callback
 		UsbHostCdcClose,	// close device
 		UsbHostCdcSof,		// sending SOF (start of frame; NULL=not used)
@@ -401,6 +402,8 @@ Bool UsbHostParseCfg(u8 dev_addr, const u8* p_desc)
 		// some CDC devices does not use interface association, need to set 2 interfaces manually
 		if ((assoc == 1) && (desc_itf->itf_class == USB_CLASS_CDC) && (desc_itf->itf_subclass == 2)) assoc = 2;
 
+		assoc = 2; // FIXME: force this for now for CDC/FTDI
+
 		// search support of this interface in class device drivers
 		u16 rem_len = desc_end - p_desc; // remaining length
 		u8 drv_id;
@@ -506,6 +509,8 @@ Bool UsbHostGetDesc(u8 dev_addr, u8 desc_type, u8 inx, u16 lang, void* buf, u16 
 // is marked as mounted.
 void UsbHostCfgComp(u8 dev_addr, u8 itf_num)
 {
+	UartPrint("UsbHostCfgComp(%u,%u)\n", dev_addr, itf_num);
+
 	// continue to next interface
 	itf_num++;
 
@@ -556,6 +561,8 @@ void UsbHostCfgComp(u8 dev_addr, u8 itf_num)
 //  xres ... transfer result USB_XRES_*
 void UsbHostEnum(u8 dev_addr, u8 xres)
 {
+	UartPrint("UsbHostEnum(%u)\n", UsbHostEnumState);
+
 	// idle
 	if (UsbHostEnumState == USB_HOST_ENUM_IDLE) return;
 

--- a/_setup.sh
+++ b/_setup.sh
@@ -63,10 +63,10 @@ case "$1" in
 	export DEVCLASS="pico"
 	export DEVDIR="!Pico"
 	;;
-     *) 
-	export DEVICE="picopad10"
-	export DEVCLASS="picopad"
-	export DEVDIR="!PicoPad10"
+     *)
+	export DEVICE="pico"
+	export DEVCLASS="pico"
+	export DEVDIR="!Pico"
 	;;
 esac
 


### PR DESCRIPTION
This PR is not intended to be merged, but rather to review to see if support can be enabled for USB Host / CDC Devices based on FTDI chipsets (FT232).

I am communicating with the Raspberry Pi Pico W through its UART.

The Pico is connected to a USB Device that internally uses an FT232 chip. This is essentially a USB CDC class device, but it presents itself as a device with a class of 0x00 and subclass of 0x00, which aren't valid.

As a result, in this PR, instead of calling `UsbHostCdcOpen`, I have a new method called `UsbHostCdcOpenFTDI`, which just creates one interface and a pair of endpoints.

In addition, instead of calling `UsbHostCdcCfg`, I have a new method called `UsbHostCdcCfgFTDI` which does three things:

1) Sends a reset packet to the FT232 (clears RX/TX, clears DTR/CTS, sets 8N1, leaves baud alone)
2) Sends a packet to enable DTR/CTS
3) Sends a packet to set the baud rate to 9600

In addition, I added a little echo support to show if you type characters in the UART as well as small logging messages to track the progress.

This code is an initial effort to communicate with these FTDI based devices (millions exist in the world).

I **think** everything here should work, but it's still not 100% there. I think it's *REALLY* close though...

Any ideas to get it running? @Panda381 - is this the general idea? Is it close?

Thanks!