### PR TITLE
Improved PicoPadVideo tool

### DIFF
--- a/_tools/PicoPadVideo/PicoPadVideo.cpp
+++ b/_tools/PicoPadVideo/PicoPadVideo.cpp
@@ -116,7 +116,17 @@ int SndOff; // sound sample offset
 // main function
 int main(int argc, char* argv[])
 {
+	BOOL BMPISBAT = TRUE;
 	int i, j;
+
+	if (argc > 1) {
+		for (i=1; i < argc; i++) {
+			if (strcmp("--bmpisnotbat", argv[i]) == 0) {
+				BMPISBAT = FALSE;
+				break;
+			}
+		}
+	}
 
 	if ((sizeof(_bmpBITMAPFILEHEADER) != 14) ||
 		(sizeof(_bmpBITMAPINFOHEADER) != 40))
@@ -255,10 +265,19 @@ int main(int argc, char* argv[])
 		}
 
 		// write image data (even image: even pixels, odd image: odd pixels)
-		if (fwrite(ImgData, 1, WIDTH*HEIGHT, fout) != WIDTH*HEIGHT)
-		{
-			printf("\nError write to output file " OUTFILE "\n");
-			return 1;
+		if (BMPISBAT) {
+			if (fwrite(ImgData, 1, WIDTH*HEIGHT, fout) != WIDTH*HEIGHT)
+			{
+				printf("\nError write to output file " OUTFILE "\n");
+				return 1;
+			}
+		} else {
+			for (j = WIDTH*HEIGHT-WIDTH; j >= 0; j -= WIDTH) {
+				if (fwrite(&ImgData[j], 1, WIDTH, fout) != WIDTH) {
+					printf("\nError write slice to output file " OUTFILE "\n");
+					return 1;
+				}
+			}
 		}
 
 		// write sound sample

--- a/_tools/PicoPadVideo/PicoPadVideo.cpp
+++ b/_tools/PicoPadVideo/PicoPadVideo.cpp
@@ -33,10 +33,8 @@ typedef unsigned char u8;
 typedef signed short s16;
 typedef unsigned short u16;
 
-typedef signed long int s32;		// on 64-bit system use "signed int"
-typedef unsigned long int u32;		// on 64-bit system use "unsigned int"
-//typedef signed int s32;
-//typedef unsigned int u32;
+typedef signed int s32;		// On 32-bit and 64-bit systems are int 32 bit
+typedef unsigned int u32;	// On 32-bit and 64-bit systems are unsigned int 32 bit
 
 typedef unsigned int BOOL;
 #define TRUE  1

--- a/_tools/PicoPadVideo/PicoPadVideo.cpp
+++ b/_tools/PicoPadVideo/PicoPadVideo.cpp
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
 		(fmt->nSamplesPerSec != 22050) || // check rate
 		(fmt->wBitsPerSample != 8)) // check bits per sample
 	{
-		printf("Incorrect format of input file %s,\n", argv[1]);
+		printf("Incorrect format of input file %s,\n", SOUNDFILE);
 		printf("  must be PCM mono 8-bit 22050Hz.\n");
 		return 1;
 	}

--- a/_tools/PicoPadVideo/PicoPadVideo.cpp
+++ b/_tools/PicoPadVideo/PicoPadVideo.cpp
@@ -114,18 +114,8 @@ int SndOff; // sound sample offset
 // main function
 int main(int argc, char* argv[])
 {
-	BOOL BMPISBAT = TRUE;
 	int processed_frames = 0;
 	int i, j;
-
-	if (argc > 1) {
-		for (i=1; i < argc; i++) {
-			if (strcmp("--bmpisnotbat", argv[i]) == 0) {
-				BMPISBAT = FALSE;
-				break;
-			}
-		}
-	}
 
 	if ((sizeof(_bmpBITMAPFILEHEADER) != 14) ||
 		(sizeof(_bmpBITMAPINFOHEADER) != 40))
@@ -270,7 +260,7 @@ int main(int argc, char* argv[])
 		}
 
 		// write image data (even image: even pixels, odd image: odd pixels)
-		if (BMPISBAT) {
+		if (bmi->biHeight < 0) {
 			if (fwrite(ImgData, 1, WIDTH*HEIGHT, fout) != WIDTH*HEIGHT)
 			{
 				printf("\nError write to output file " OUTFILE "\n");
@@ -309,4 +299,3 @@ int main(int argc, char* argv[])
 
 	return 0;
 }
-

--- a/_tools/PicoPadVideo/PicoPadVideo.cpp
+++ b/_tools/PicoPadVideo/PicoPadVideo.cpp
@@ -117,6 +117,7 @@ int SndOff; // sound sample offset
 int main(int argc, char* argv[])
 {
 	BOOL BMPISBAT = TRUE;
+	int processed_frames = 0;
 	int i, j;
 
 	if (argc > 1) {
@@ -214,7 +215,13 @@ int main(int argc, char* argv[])
 
 		// open image file
 		f = fopen(Filename, "rb");
-		if (f == NULL) break;
+		if (f == NULL) {
+			if (i == 0) {
+				continue;
+			} else {
+				break;
+			}
+		}
 
 		// read image file
 		int size2 = (int)fread(Img, 1, IMGSIZE, f);
@@ -293,13 +300,14 @@ int main(int argc, char* argv[])
 		*/
 		if (SndOff > SndNum) SndOff = SndNum;
 
+		processed_frames++;
 		printf(".");
 	}
 
 	// close output file
 	fclose(fout);
 
-	printf("\nProcessed %d frames\n", i);
+	printf("\nProcessed %d frames\n", processed_frames);
 
 	return 0;
 }

--- a/_tools/PicoPadVideo/PicoPadVideo.cpp
+++ b/_tools/PicoPadVideo/PicoPadVideo.cpp
@@ -20,7 +20,7 @@
 //#define SOUNDSAMP_DEL (FPS / (SOUNDRATE - SOUNDRATE/FPS*FPS)) // number of frames to delete 1 sound sample (= 2)
 #define SOUNDFILE "SOUND.wav"
 #define OUTFILE "VIDEO.VID"
-#define BMPFILE "BMP\\%06d.bmp"
+#define BMPFILE "BMP/%06d.bmp"
 #define WIDTH 160 // image width
 #define HEIGHT 240 // image height
 #define IMGSIZE (WIDTH*HEIGHT + 4*256 + 54 + 1000) // input image size + reserve (= 40474)


### PR DESCRIPTION
PicoPadVideo tool is now usable on any platform (not only Windows), i.e. Linux and Mac. Can be compilled on 32 bit and 64 bit OS without modifying source. Tool can now process BMP files, which has array of pixels organized from last image line to first (this is default for BMP files) and BMP filenames can start from 000001.bmp, because ffmpeg create image files from video starting by 1 not 0. At last fixed one SIGSEGV.