### PR TITLE
Fix: emulation (decoding) of 0xED prefixed Z80 instructions

### DIFF
--- a/_lib/emu/emu_z80_ed.c
+++ b/_lib/emu/emu_z80_ed.c
@@ -14,8 +14,10 @@
 //	This source code is freely available for any purpose, including commercial.
 //	It is possible to take and modify the code or parts of it, without restriction.
 
+	u8 op = Z80_ProgByte(cpu);
+
 	// switch 0xED operation code
-	switch (Z80_ProgByte(cpu))
+	switch (op)
 	{
 	// IN B,(C)
 	case 0x40:


### PR DESCRIPTION
Fixing emulation (decoding) of 0xED prefixed Z80 instructions. 
Original code did not decode the opcode "parameters" (registers) correctly because it used 0xED prefix as the decoded opcode instead of using the next prog. byte.